### PR TITLE
DEV: fix for run_combine_cov; reentrancy fix for scan_phrogs

### DIFF
--- a/phables/workflow/rules/coverm.smk
+++ b/phables/workflow/rules/coverm.smk
@@ -90,9 +90,10 @@ rule run_combine_cov:
                 counts[l[0]] = 0
         for file in input.files:
             with open(file, "r") as f:
+                f.readline()
                 for line in f:
                     l = line.strip().split()
-                    counts[l[0]] += l[1]
+                    counts[l[0]] += float(l[1])
         with open(output[0], "w") as out:
             for contig in list(counts.keys()):
                 out.write(f"{contig}\t{counts[contig]}\n")

--- a/phables/workflow/rules/genes.smk
+++ b/phables/workflow/rules/genes.smk
@@ -51,7 +51,7 @@ rule scan_phrogs:
         os.path.join("..", "envs", "mmseqs.yaml")
     shell:
         """
-        mkdir {params.out_path}
+        mkdir -p {params.out_path}
         mmseqs createdb {input} {params.target_seq} > {log}
         mmseqs search {params.target_seq} {input.db} {params.results_mmseqs} {params.tmp} --threads {threads} -s 7 > {log}
         mmseqs createtsv {params.target_seq} {input.db} {params.results_mmseqs} {output} --threads {threads} --full-header > {log}


### PR DESCRIPTION
Hey Vijini, I ran into a couple of errors which this should fix. I'm also having another issue. When run_phables doesn't find any phages it does not write the `resolved_paths.fasta` file, or the `resolved_phages` directory. This tells snakemake that the job failed when it actually finished technically without error. I didn't try to patch it because I didn't know how you wanted to handle that sort of situation. Something like initialising an empty file and removing the directory from outputs could work.