### PR TITLE
Adding dockerfile

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -48,9 +48,11 @@ ENV PATH /opt/miniforge3/bin:$PATH
 ARG PHABLES_VERSION=1.3.2
 
 RUN set -eux ; \
-  mamba install -y -c conda-forge -c bioconda -c defaults \
-  phables=${PHABLES_VERSION} ; \
-  mamba install -y -c gurobi gurobi
+  mamba install -y -c conda-forge -c anaconda -c bioconda -c defaults \
+  phables=${PHABLES_VERSION} curl "koverage>=0.1.8" minimap2 samtools \
+  "mmseqs2=13.45111" biopython python-igraph pysam "networkx>=2.8.6" \
+  scipy numpy pandas  more-itertools tqdm click "metasnek>=0.0.3" \
+  fraggenescan hmmer
 ENV PATH /opt/miniforge3/bin:$PATH
 RUN conda clean -af -y
 

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,0 +1,57 @@
+
+#
+# phables
+#
+
+FROM --platform=linux/amd64 ubuntu:20.04
+FROM gurobi/optimizer:latest
+
+ENV DEBIAN_FRONTEND="noninteractive"
+
+
+ARG LIBFABRIC_VERSION=1.18.1
+
+# Install required packages and dependencies
+RUN   apt -y update \
+      && apt -y install build-essential wget doxygen gnupg gnupg2 curl apt-transport-https software-properties-common  \
+ git vim gfortran libtool python3-venv ninja-build python3-pip \
+      libnuma-dev python3-dev \
+      && apt -y remove --purge --auto-remove cmake \
+      && wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null\
+ | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null \
+      && apt-add-repository -y "deb https://apt.kitware.com/ubuntu/ jammy-rc main" \
+      && apt -y update 
+
+# Build and install libfabric
+RUN (if [ -e /tmp/build ]; then rm -rf /tmp/build; fi;) \
+      && mkdir -p /tmp/build \
+      && cd /tmp/build \
+      && wget https://github.com/ofiwg/libfabric/archive/refs/tags/v${LIBFABRIC_VERSION}.tar.gz \
+      && tar xf v${LIBFABRIC_VERSION}.tar.gz \
+      && cd libfabric-${LIBFABRIC_VERSION} \ 
+      && ./autogen.sh \
+      && ./configure \
+      && make -j 16 \ 
+      && make install
+
+#
+# Install miniforge
+#
+RUN set -eux ; \
+  curl -LO https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh ; \
+  bash ./Miniforge3-* -b -p /opt/miniforge3 -s ; \
+  rm -rf ./Miniforge3-*
+ENV PATH /opt/miniforge3/bin:$PATH
+#
+# Install conda environment
+# 
+ARG PHABLES_VERSION=1.3.2
+
+RUN set -eux ; \
+  mamba install -y -c conda-forge -c bioconda -c defaults \
+  phables=${PHABLES_VERSION} ; \
+  mamba install -y -c gurobi gurobi
+ENV PATH /opt/miniforge3/bin:$PATH
+RUN conda clean -af -y
+
+RUN phables install

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -49,11 +49,9 @@ ARG PHABLES_VERSION=1.3.2
 
 RUN set -eux ; \
   mamba install -y -c conda-forge -c anaconda -c bioconda -c defaults \
-  phables=${PHABLES_VERSION} curl "koverage>=0.1.8" minimap2 samtools \
-  "mmseqs2=13.45111" biopython python-igraph pysam "networkx>=2.8.6" \
-  scipy numpy pandas  more-itertools tqdm click "metasnek>=0.0.3" \
-  fraggenescan hmmer
+  phables=${PHABLES_VERSION} ;
 ENV PATH /opt/miniforge3/bin:$PATH
 RUN conda clean -af -y
-
+RUN mkdir -p /phables /opt/gurobi
+RUN ln -s /opt/miniforge3/lib/python3.10/site-packages/phables/workflow/conda /conda
 RUN phables install

--- a/container/README.md
+++ b/container/README.md
@@ -2,12 +2,52 @@
 
 Please note that this container is hosted on [docker hub](https://hub.docker.com/r/linsalrob/phables) and we recommend you use the latest version there.
 
-# Running the container
+# Installing guorobi
 
-You will need to use the [Gurobi WSL]( ) license, and then you can use a command along the lines of:
+For the linear solver, you need the [Gurobi WLS](https://www.gurobi.com/features/academic-wls-license/) license. Get that file, which is called `gurobi.lic` by default, and put it in your home directory, or another location that you know where it is.
+
+# Running the container with singularity (recommended)
+
+We need to mount three locations that are writable for `phables` to work with singularity.
+
+1. You need to mount the `gurobi.lic` file, and that needs to end up at `/opt/gurobi/gurobi.lic`. In the example here, it is in the current working directory, `$PWD`.
+2. You need a temporary directory where conda can install some files. They are installed on the first run, and reused after that. In this example, I am using `/tmp`. You need to mount this to `/conda` which is actually a symlink to the correct location under the snakemake directory.
+3. You need your `.gfa` and `.fastq` files, and a location for the output. In this example, I have a directory called `Sim_Phage`. You should mount this to `/phables`. An important point here is to add the `/` to the end of your directory name, but _not_ to the `/phables`, and then the `.gfa` and `reads` will be in the `/phables` directory. 
+
+> **NOTE:** when you specify the paths, it is important that they are absolute paths (i.e. beginning with `$PWD` or `/`), as relative paths don't work.
+
+
+## Create the `.sif` image
+
+The first step is to create the .sif image in a directory.
+
+Check [docker hub](https://hub.docker.com/r/linsalrob/phables) for the latest version. In this example, I'm using version 0.6 but it may have been updated after that.
 
 ```
-sudo docker run --volume=$PWD/Sim_Phage:/Sim_Phage --volume=$PWD/gurobi.lic:/opt/gurobi/gurobi.lic:ro phables phables run --input /Sim_Phage/assembly_graph_after_simplification.gfa --reads /Sim_Phage/reads/
+IMAGE_DIR=<path to singularity image>
+mkdir -p $IMAGE_DIR
+singularity pull --dir $IMAGE_DIR docker://linsalrob/phables:v0.5_sneaky_sleeky
 ```
 
-We are actively making this work.
+You can set `IMAGE_DIR` to any path you can write to.
+
+
+## Run the container
+
+```
+singularity exec --bind /tmp:/conda,$PWD/Sim_Phage/:/phables,$PWD/gurobi.lic:/opt/gurobi/gurobi.lic singularity/phables_0.6_gogo phables run --input /phables/assembly_graph_after_simplification.gfa --reads /phables/reads/ --output /phables/phables --threads 32
+```
+
+# Running the container with docker
+
+The approach is very similar, except instead of the `--bind` you need to use `--volume`. Note that you will need to have root access for this to work.
+
+```
+docker pull linsalrob/phables:v0.6_gogo
+
+sudo docker run --volume=$PWD/Sim_Phage/:/phables --volume=/tmp:/conda --volume=$PWD/gurobi.lic:/opt/gurobi/gurobi.lic:ro phables phables run --input /phables/assembly_graph_after_simplification.gfa --reads /phables/reads/ --output /phables/phables --threads 32
+```
+
+
+
+singularity exec --bind /scratch/pawsey1018/edwa0468/tmp:/opt/miniforge3/lib/python3.10/site-packages/phables/workflow/conda,$PWD/testy/Sim_Phage/:/phables,$PWD/gurobi.lic:/opt/gurobi/gurobi.lic testy/phables_v0.5_sneaky_sleeky.sif phables run --input /phables/assembly_graph_after_simplification.gfa --reads /phables/reads/ --output /phables/phables --threads 32

--- a/container/README.md
+++ b/container/README.md
@@ -1,0 +1,13 @@
+# Docker container
+
+Please note that this container is hosted on [docker hub](https://hub.docker.com/r/linsalrob/phables) and we recommend you use the latest version there.
+
+# Running the container
+
+You will need to use the [Gurobi WSL]( ) license, and then you can use a command along the lines of:
+
+```
+sudo docker run --volume=$PWD/Sim_Phage:/Sim_Phage --volume=$PWD/gurobi.lic:/opt/gurobi/gurobi.lic:ro phables phables run --input /Sim_Phage/assembly_graph_after_simplification.gfa --reads /Sim_Phage/reads/
+```
+
+We are actively making this work.


### PR DESCRIPTION
This PR adds a dockerfile which allows you to run `phables` either from docker (but you need root) or singularity. There are a couple of tricks mostly associated with ensuring you correctly mount remote directories in the right places, but the README clarifies those steps.